### PR TITLE
Add privacy pass security considerations

### DIFF
--- a/draft-yun-privacypass-arc.md
+++ b/draft-yun-privacypass-arc.md
@@ -128,19 +128,20 @@ presentation. Otherwise, Clients invoke the issuance protocol to obtain a
 credential. This interaction is shown below.
 
 ~~~ aasvg
-                                      +--------------------------.
+                                      +---------------------------+
 +--------+          +----------+      |  +--------+   +--------+  |
 | Client |          | Attester |      |  | Issuer |   | Origin |  |
 +---+----+          +-----+----+      |  +----+---+   +---+----+  |
-    |                     |            `------|-----------|------'
+    |                     |           +-------|-----------|------ +
     |                     |                   |           |
-    |<----- Request ------+                   |           |
-    +-- TokenChallenge -->|                   |           |
-    |                     |<== Attestation ==>|           |
+    |--------------------- Request ---------------------->|
+    <----------------- TokenChallenge --------------------+
     |                     |                   |           |
-    |                     +------ CredentialRequest ----->|
-    |                     |<---- CredentialResponse ------+
-    |<-- Request+Token ---+                   |           |
+    | <== Attestation ==> |                   |           |
+    +----------- CredentialRequest ---------->|           |
+    |<---------- CredentialResponse ----------+           |
+    |                     |                   |           |
+    |----------- Request + Presentation ----------------->|
     |                     |                   |           |
 ~~~
 {: #fig-overview title="Issuance and Redemption Overview"}

--- a/draft-yun-privacypass-arc.md
+++ b/draft-yun-privacypass-arc.md
@@ -384,7 +384,22 @@ This function returns True if the CredentialToken is valid, and False otherwise.
 
 # Security Considerations {#security}
 
-TODO: unlinkability of tokens across presentations
+Privacy considerations for tokens based on deployment details, such as issuer configuration and issuer selection, are discussed in {{Section 6.1 of ARCHITECTURE}}.
+
+The presentation context is considered public metadata, and is known to both the Client and Origin. The mechanism by which public metadata is made available to Client and Orign is out of scope for this document. The privacy considerations in {{ARCHITECTURE}} ofer a guide for determining what type of information is appropriate to include, and in what circumstances.
+
+## Unconditional Issuance Unlinkability
+
+Client credential requests are constructed such that a server cannot distinguish between any two credential requests from the same client and two requests from different clients, even with unbounded computation. We refer to this property as unconditional issuance unlinkability. This property is achieved by the way the credential requests are constructed. In particular, each credential request consists of Pedersen commitments with fresh blinding factors, which are used to commit to a freshly generated client secret. The resulting request is therefore perfectly hiding, and independent from other requests from the same client.
+
+## Unconditional Issuance-to-Presentation Unlinkability
+
+Client credential requests are constructed such that a server cannot link a presentation to a credential request, even with unbounded computation. We refer to this property as unconditional issuance-to-presentation unlinkability. This property is achieved because the credential request is perfectly hiding, and the blinding factors used in the credential request are removed before creating a presentation.
+
+## Presentation Unlinkability
+
+Client presentations are constructed such that a server cannot link multiple presentations as coming from the same credential. We refer to this property as presentation unlinkability. This property is achieved by re-randomizing credentials every time they are presented, so that each presentation is indistinguishable from all other presentations made from credentials issued with the same server keys and the same public metadata. There is a reduction in the indistinguishability set in the case of nonce collisions, as detailed in {{Section 7.2 of AUTHSCHEME}}
+
 
 # IANA Considerations
 


### PR DESCRIPTION
Added some security considerations to the privacy pass section, working off of other specs:

https://datatracker.ietf.org/doc/html/draft-ietf-privacypass-architecture-16#section-6
https://datatracker.ietf.org/doc/draft-ietf-privacypass-public-metadata-issuance/
https://datatracker.ietf.org/doc/rfc9497/

Some of this repeats the security considerations in the ARC CFRG spec (eg Client Issuance Unlinkability), I'm not sure if it's okay to repeat across both specs, or where they would belong best.