### PR TITLE
Remove extra response from presentation struct

### DIFF
--- a/draft-yun-cfrg-arc.md
+++ b/draft-yun-cfrg-arc.md
@@ -641,11 +641,10 @@ struct {
   uint8 response1[Ns];
   uint8 response2[Ns];
   uint8 response3[Ns];
-  uint8 response4[Ns];
 } Presentation
 ~~~
 
-The length of this structure is `Npresentation = 4*Ne + 6*Ns`.
+The length of this structure is `Npresentation = 4*Ne + 5*Ns`.
 
 ### Presentation Verification
 


### PR DESCRIPTION
Fix a typo where I had an extra response field in the presentation struct