### PR TITLE
Remove P384 from the list of ARC supported curves

### DIFF
--- a/draft-yun-cfrg-arc.md
+++ b/draft-yun-cfrg-arc.md
@@ -1482,42 +1482,6 @@ contextString is "ARCV1-P256".
     string using Octet-String-to-Field-Element from {{SEC1}}. This function can fail if the
     input does not represent a Scalar in the range \[0, `G.Order()` - 1\].
 
-## ARC(P-384)
-
-This ciphersuite uses P-384 {{NISTCurves}} for the Group.
-The value of the ciphersuite identifier is "P384". The value of
-contextString is "ARCV1-P384".
-
-- Group: P-384 (secp384r1) {{NISTCurves}}
-  - Order(): Return 0xffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973.
-  - Identity(): As defined in {{NISTCurves}}.
-  - Generator(): As defined in {{NISTCurves}}.
-  - RandomScalar(): Implemented by returning a uniformly random Scalar in the range
-    \[0, `G.Order()` - 1\]. Refer to {{random-scalar}} for implementation guidance.
-  - HashToGroup(x, info): Use hash_to_curve with suite P384_XMD:SHA-384_SSWU_RO\_
-    {{!I-D.irtf-cfrg-hash-to-curve}}, input `x`, and DST =
-    "HashToGroup-" || contextString || info.
-  - HashToScalar(x, info): Use hash_to_field from {{!I-D.irtf-cfrg-hash-to-curve}}
-    using L = 72, `expand_message_xmd` with SHA-384, input `x` and
-    DST = "HashToScalar-" || contextString || info, and
-    prime modulus equal to `Group.Order()`.
-  - ScalarInverse(s): Returns the multiplicative inverse of input Scalar `s` mod `Group.Order()`.
-  - SerializeElement(A): Implemented using the compressed Elliptic-Curve-Point-to-Octet-String
-    method according to {{SEC1}}; Ne = 49.
-  - DeserializeElement(buf): Implemented by attempting to deserialize a 49-byte array to
-    a public key using the compressed Octet-String-to-Elliptic-Curve-Point method according to {{SEC1}},
-    and then performs partial public-key validation as defined in section 5.6.2.3.4 of
-    {{!KEYAGREEMENT=DOI.10.6028/NIST.SP.800-56Ar3}}. This includes checking that the
-    coordinates of the resulting point are in the correct range, that the point is on
-    the curve, and that the point is not the point at infinity. Additionally, this function
-    validates that the resulting element is not the group identity element.
-    If these checks fail, deserialization returns an InputValidationError error.
-  - SerializeScalar(s): Implemented using the Field-Element-to-Octet-String conversion
-    according to {{SEC1}}; Ns = 48.
-  - DeserializeScalar(buf): Implemented by attempting to deserialize a Scalar from a 48-byte
-    string using Octet-String-to-Field-Element from {{SEC1}}. This function can fail if the
-    input does not represent a Scalar in the range \[0, `G.Order()` - 1\].
-
 ## Random Scalar Generation {#random-scalar}
 
 Two popular algorithms for generating a random integer uniformly distributed in


### PR DESCRIPTION
From discussion on the CFRG list and with authors, we decided to move to P256 instead of P384 for performance reasons. I kept P384 as a curve option originally, but it seems better to remove it for several reasons:
- We want to move the proof to use the sigma proof spec, which only supports P256: https://github.com/mmaker/draft-zkproof-sigma-protocols/blob/main/draft-orru-zkproof-sigma-protocols.md#ciphersuites-ciphersuites
- Implementors would prefer fewer rather than more curves. This will also help interoperability and adoption. Eg from the cfrg mailing list, on the call for adoption for sigma protocols, Chris Patton says:
> As an implementer, in general I think fewer choices for curves is always better. In this case, I would rather have P384 only than a bunch of different options (including P256, ristretto, decaf, etc.). It just strikes me as odd to choose P384 over something smaller and more widely used, like P256. For TLS for example, both X25519 and P256 are much, much more common than P384.