### PR TITLE
Add challenge digest to privacypass spec

### DIFF
--- a/draft-yun-privacypass-arc.md
+++ b/draft-yun-privacypass-arc.md
@@ -399,10 +399,12 @@ The structure fields are defined as follows:
 
 - "token_type" is a 2-octet integer, in network byte order, equal to 0xE5AC.
 
+- "presentation_nonce" is a 32-bit encoding of the nonce output from ARC.
+
+- "challenge_digest" is a 32-octet value containing the hash of the original TokenChallenge, SHA-256(TokenChallenge).
+
 - "issuer_key_id" is a Nid-octet identifier for the Issuer Public Key, computed
 as defined in {{setup}}.
-
-- "presentation_nonce" is a 32-bit encoding of the nonce output from ARC.
 
 - "presentation" is a Npresentation-octet presentation, set to the serialized
 `presentation` value (see {{Section 4.3.2 of ARC}} for serialiation details).

--- a/draft-yun-privacypass-arc.md
+++ b/draft-yun-privacypass-arc.md
@@ -388,8 +388,9 @@ The resulting Token value is then constructed as follows:
 ~~~
 struct {
     uint16_t token_type = 0xE5AC; /* Type ARC(P-256) */
-    uint8_t issuer_key_id[Nid];
     uint32_t presentation_nonce;
+    uint8_t challenge_digest[32];
+    uint8_t issuer_key_id[Nid];
     uint8_t presentation[Npresentation];
 } Token;
 ~~~


### PR DESCRIPTION
Currently, the default privacy pass token structure is:
```
struct {
    uint16_t token_type;
    uint8_t nonce[32];
    uint8_t challenge_digest[32];
    uint8_t token_key_id[Nid];
    uint8_t authenticator[Nk];
} Token;
```

The ARC token structure is:
```
struct {
    uint16_t token_type = 0xE5AC; /* Type ARC(P-256) */
    uint8_t issuer_key_id[Nid];
    uint32_t presentation_nonce;
    uint8_t presentation[Npresentation];
} Token;
```

Where we have a parallel between the following fields:
- token_type is the same
- token_key_id is the same as issuer_key_id in function. Different name because there is no longer the concept of the "token authentication key", in ARC the issuer key ID is the same thing as the authentication key.
- nonce is sort of the same as the presentation_nonce, in that it's revealed at presentation time and must be unique. But unlike in the base token protocol, one credential can be made with many nonces, so we wanted the field names to be different.
- We don't need to send the challenge_digest, as this is assumed to be already known at the recipient side. This saves us some space.
- The authenticator for PAT was an RSA signature; the presentation is the equivalent of this, which ties the token to all the preceding in formation, in a way that can only be verified by the issuer key.

However, upon further consideration, we still want to have a `challenge_digest` as the recipient may have multiple challenge_digests that are valid, and we don't want to make them try all of them to figure out which to use. So, this PR adds `challenge_digest` back to the struct. It also reorders the fields so that they have the same order as the default privacy pass protocol structure.