### PR TITLE
4 octets instead of 32 bits

### DIFF
--- a/draft-yun-privacypass-arc.md
+++ b/draft-yun-privacypass-arc.md
@@ -399,7 +399,7 @@ The structure fields are defined as follows:
 
 - "token_type" is a 2-octet integer, in network byte order, equal to 0xE5AC.
 
-- "presentation_nonce" is a 32-bit encoding of the nonce output from ARC.
+- "presentation_nonce" is a 4-octet integer, in network byte order, equal to the nonce output from ARC.
 
 - "challenge_digest" is a 32-octet value containing the hash of the original TokenChallenge, SHA-256(TokenChallenge).
 


### PR DESCRIPTION
Close #17 

`challenge_digest` is already defined in that section (as below), so I didn't change anything there.

```
"challenge_digest" is a 32-octet value containing the hash of the original TokenChallenge, SHA-256(TokenChallenge).
```