### PR TITLE
Rename `cfrg` spec to `privacypass-crypto`

### DIFF
--- a/draft-yun-privacypass-arc.md
+++ b/draft-yun-privacypass-arc.md
@@ -12,10 +12,10 @@ v: 3
 venue:
   group: PRIVACYPASS
   type: Privacy Pass
-  mail: WG@example.com
-  arch: https://example.com/WG
-  github: USER/REPO
-  latest: https://example.com/LATEST
+  mail: privacy-pass@ietf.org
+  arch: https://mailarchive.ietf.org/arch/browse/privacy-pass
+  github: chris-wood/draft-arc
+  latest: https://chris-wood.github.io/draft-arc/draft-yun-privacypass-arc.html
 
 author:
  -

--- a/draft-yun-privacypass-crypto-arc.md
+++ b/draft-yun-privacypass-crypto-arc.md
@@ -3,18 +3,18 @@ title: "Anonymous Rate-Limited Credentials"
 abbrev: "ARC"
 category: info
 
-docname: draft-yun-cfrg-arc-latest
-submissiontype: IRTF
+docname: draft-yun-privacypass-crypto-arc-latest
+submissiontype: IETF
 number:
 date:
-v: 3
+v: 0
 venue:
-  group: "Crypto Forum"
-  type: ""
-  mail: "cfrg@ietf.org"
-  arch: "https://mailarchive.ietf.org/arch/browse/cfrg"
-  github: "chris-wood/draft-arc"
-  latest: "https://chris-wood.github.io/draft-arc/draft-yun-cfrg-arc.html"
+  group: PRIVACYPASS
+  type: Privacy Pass
+  mail: privacy-pass@ietf.org
+  arch: https://mailarchive.ietf.org/arch/browse/privacy-pass
+  github: chris-wood/draft-arc
+  latest: https://chris-wood.github.io/draft-arc/draft-yun-privacypass-crypto-arc.html
 
 author:
  -


### PR DESCRIPTION
- Rename `cfrg` spec to `privacypass-crypto`, to reflect that the call for adoption is happening in the Privacy Pass working group (both for the Privacy Pass issuance workflow, and for the crypto protocol).
- Update internal names and links
- Also sneak in a typo fix for the RandomScalar range, to start at 1 instead of 0.

Note that the privacypass spec does not yet reference the updated name for the crypto spec, because we need to publish that first before updating the privacypass spec reference (or else the build breaks). Will do that as a fast-follow.