### PR TITLE
Update ARC crypto reference

### DIFF
--- a/draft-yun-privacypass-arc.md
+++ b/draft-yun-privacypass-arc.md
@@ -30,7 +30,7 @@ author:
     email: caw@heapingbits.net
 
 normative:
-  ARC: I-D.draft-yun-cfrg-arc
+  ARC: I-D.draft-yun-privacypass-crypto-arc
   ARCHITECTURE: RFC9576
   AUTHSCHEME: RFC9577
   ISSUANCE: RFC9578


### PR DESCRIPTION
Update ARC crypto reference from `cfrg` to `privacypass-crypto`.

We couldn't do this in the previous PR because we had not yet pushed the `privacypass-crypto` spec to Datatracker, so making this change would have broken the spec build.