### PR TITLE
Update draft names to include "IETF", update links

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Automatically generated CODEOWNERS
 # Regenerate with `make update-codeowners`
-draft-yun-cfrg-arc.md cathie@apple.com caw@heapingbits.net
-draft-yun-privacypass-arc.md cathie@apple.com caw@heapingbits.net
+draft-ietf-privacypass-arc-crypto.md cathieyun@gmail.com caw@heapingbits.net
+draft-ietf-privacypass-arc-protocol.md cathieyun@gmail.com caw@heapingbits.net

--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,8 @@
 /versioned/
 Gemfile.lock
 archive.json
-draft-yun-cfrg-arc.xml
-draft-yun-privacypass-arc.xml
+draft-ietf-privacypass-arc-crypto.xml
+draft-ietf-privacypass-arc-protocol.xml
 package-lock.json
 report.xml
 !requirements.txt

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ This is the working area for the following Internet Drafts.
 
 ## Anonymous Rate-Limited Credentials Cryptography
 
-* [Editor's Copy](https://ietf-wg-privacypass.github.io/draft-arc/#go.draft-privacypass-arc-crypto.html)
-* [Datatracker Page](https://datatracker.ietf.org/doc/draft-privacypass-arc-crypto/)
-* [Individual Draft](https://datatracker.ietf.org/doc/html/draft-privacypass-arc-crypto)
-* [Compare Editor's Copy to Individual Draft](https://ietf-wg-privacypass.github.io/draft-arc/#go.draft-privacypass-arc-crypto.diff)
+* [Editor's Copy](https://ietf-wg-privacypass.github.io/draft-arc/#go.draft-ietf-privacypass-arc-crypto.html)
+* [Datatracker Page](https://datatracker.ietf.org/doc/draft-ietf-privacypass-arc-crypto/)
+* [Individual Draft](https://datatracker.ietf.org/doc/html/draft-ietf-privacypass-arc-crypto)
+* [Compare Editor's Copy to Individual Draft](https://ietf-wg-privacypass.github.io/draft-arc/#go.draft-ietf-privacypass-arc-crypto.diff)
 
 ## Privacy Pass Issuance Protocol for Anonymous Rate-Limited Credentials
 
-* [Editor's Copy](https://ietf-wg-privacypass.github.io/draft-arc/#go.draft-privacypass-arc-protocol.html)
-* [Datatracker Page](https://datatracker.ietf.org/doc/draft-privacypass-arc-protocol)
-* [Individual Draft](https://datatracker.ietf.org/doc/html/draft-privacypass-arc-protocol)
-* [Compare Editor's Copy to Individual Draft](https://ietf-wg-privacypass.github.io/draft-arc/#go.draft-privacypass-arc-protocol.diff)
+* [Editor's Copy](https://ietf-wg-privacypass.github.io/draft-arc/#go.draft-ietf-privacypass-arc-protocol.html)
+* [Datatracker Page](https://datatracker.ietf.org/doc/draft-ietf-privacypass-arc-protocol)
+* [Individual Draft](https://datatracker.ietf.org/doc/html/draft-ietf-privacypass-arc-protocol)
+* [Compare Editor's Copy to Individual Draft](https://ietf-wg-privacypass.github.io/draft-arc/#go.draft-ietf-privacypass-arc-protocol.diff)
 
 
 ## Contributing

--- a/draft-ietf-privacypass-arc-crypto.md
+++ b/draft-ietf-privacypass-arc-crypto.md
@@ -3,7 +3,7 @@ title: "Anonymous Rate-Limited Credentials Cryptography"
 abbrev: "ARC Cryptography"
 category: info
 
-docname: draft-privacypass-arc-crypto-latest
+docname: draft-ietf-privacypass-arc-crypto-latest
 submissiontype: IETF
 number:
 date:
@@ -14,7 +14,7 @@ venue:
   mail: privacy-pass@ietf.org
   arch: https://mailarchive.ietf.org/arch/browse/privacy-pass
   github: ietf-wg-privacypass/draft-arc
-  latest: https://ietf-wg-privacypass.github.io/draft-arc/draft-privacypass-arc-crypto.html
+  latest: https://ietf-wg-privacypass.github.io/draft-arc/draft-ietf-privacypass-arc-crypto.html
 
 author:
  -

--- a/draft-ietf-privacypass-arc-protocol.md
+++ b/draft-ietf-privacypass-arc-protocol.md
@@ -3,7 +3,7 @@ title: "Privacy Pass Issuance Protocol for Anonymous Rate-Limited Credentials"
 abbrev: "Privacy Pass Issuance Protocol for ARC"
 category: std
 
-docname: draft-privacypass-arc-protocol-latest
+docname: draft-ietf-privacypass-arc-protocol-latest
 submissiontype: IETF
 consensus: true
 number:
@@ -15,7 +15,7 @@ venue:
   mail: privacy-pass@ietf.org
   arch: https://mailarchive.ietf.org/arch/browse/privacy-pass
   github: ietf-wg-privacypass/draft-arc
-  latest: https://ietf-wg-privacypass.github.io/draft-arc/draft-privacypass-arc-issuance.html
+  latest: https://ietf-wg-privacypass.github.io/draft-arc/draft-ietf-privacypass-arc-protocol.html
 
 author:
  -
@@ -35,7 +35,7 @@ author:
     email: armfazh@cloudflare.com
 
 normative:
-  ARC: I-D.draft-privacypass-arc-crypto
+  ARC: I-D.draft-yun-privacypass-crypto-arc
   ARCHITECTURE: RFC9576
   AUTHSCHEME: RFC9577
   ISSUANCE: RFC9578


### PR DESCRIPTION
This PR fixes:
- Naming errors: I previously named the specs `draft-privacypass-arc-*` but left out the `ietf`. This updates all the names to be `draft-ietf-privacypass-arc-*` instead.
- Also updates the links to point to the right place, once the names and tags are updated.

Follow-up work:
1. After this PR is merged, tag it with `draft-ietf-privacypass-arc-crypto-00`
2. Then, open another PR to update the Datatracker ID reference in `-protocol` to point to that new tag for the `-crypto` spec. (I can't do that in this PR, because the tag does not yet exist)
3. Merge that PR, then tag it with `draft-ietf-privacypass-arc-protocol-00`
4. Also, get Armando added as a code owner (maybe need to add him to the `ietf-wg-privacypass` group?) and add him to the CODEOWNERS file.
5. Delete the incorrect tags from the `draft-arc` repo :)